### PR TITLE
V0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Release 0.16
 
 * Added **Weather Alerts**. If selected during config, there will now be a new sensor added, called `weather_alerts`. The state of the sensor shows the number of alerts for the selected location, and the Attributes hold the details for the alert. See the README.md file for an example on how to use this.<br>
+Update frequency for the Weather Alerts follows what you set for the Forecast - Default 30 min.<br>
 **NOTE**: You must remove the Integration and Re-Add it before given the option of adding the Weather Alerts sensor.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release 0.16
+
+* Added **Weather Alerts**. If selected during config, there will now be a new sensor added, called `weather_alerts`. The state of the sensor shows the number of alerts for the selected location, and the Attributes hold the details for the alert. See the README.md file for an example on how to use this.<br>
+**NOTE**: You must remove the Integration and Re-Add it before given the option of adding the Weather Alerts sensor.
+
+
 ### Release 0.14
 
 * Added new sensor `weather_icon` holding the icon code for the current condition. Static icons, that works with this icon code, can be downloaded from [this site](https://www.weatherbit.io/api/meta).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If the location is configured in Home Assistant, it will be selected as the defa
 
 During setup you will have the option of installing Individual sensors for each of the *Current Day* values plus the next seven days of Forecast. This will be setup by default, but you can opt not to install them by deselecting the checkbox. If you deselect, and later want the sensors installed, you will have to remove the Integration and then set it up again.
 
+You will also have the option of adding *Weather Alerts* for your location. It is de-selected by default, but if you mark the box, an additional sensor will be created for Weather Alerts, showing the number of Alerts in the State, and the details for these alerts in the attributes. If you want to add or remove this sensor, delete the Integrations and re-add it to the system.
+
 The units used are defined by the Unit System set in the *General* section of the *Configuration* page. If you change the unit system here, you will have to restart Home Assistent for this Integration to reflect the changes.
 
 **You can only add locations through the integrations page, not in configuration files.**

--- a/README.md
+++ b/README.md
@@ -47,7 +47,20 @@ The units used are defined by the Unit System set in the *General* section of th
 
 ## API Key for Weatherbit
 This integration requires an API Key that can be retrieved for free from the Weatherbit Webpage. Please [go here](https://www.weatherbit.io/account/create) to apply for your personal key.
-This key allows you to make 500 calls pr. day, and as this Integration uses 4 calls per hour (96 pr day) with the default update interval, you can add a maximum of 5 locations to your setup, without exceeding the limit per day.
+This key allows you to make 500 calls pr. day, and as this Integration uses 4 calls per hour (96 pr day) with the default update interval, and with that, you can add a maximum of 5 locations to your setup, without exceeding the limit per day.
+If you activate the *Weather Alerts* that will add another 2 calls per hour with the default settings.
+
+**API KEY ESTIMATOR**<br>
+* **Forecast** 1 call pr.cycle, so default 2 per hour with a 30 min update interval.
+* **Current Data** 1 call pr.cycle, so default 2 per hour with a 30 min update interval.
+* **Weather Alerts** 1 call pr.cycle, so default 2 per hour with a 30 min update interval.
+
+If you set Forecast Update Interval to every 60 min, and Current Data Update Interval to every 10 min, and activate the Weather Alerts, the calculation would look like the following:<br>
+
+* *Forecast* 1 * 60min * 24hrs = 24 calls per day
+* *Current Data* 1 * 10min * 24hrs = 144 calls per day
+* *Weather Alerts* 1 * 60min * 24hrs = 24 calls per day
+* **Total**: 192 calls per day. So with this setup, you can have 2 locations in total configured.
 
 ### CONFIGURATION VARIABLES
 **API Key**<br>
@@ -91,3 +104,10 @@ This key allows you to make 500 calls pr. day, and as this Integration uses 4 ca
 
 &nbsp;&nbsp;*Default value:*<br>
 &nbsp;&nbsp;True
+
+**Activate Alertss**<br>
+&nbsp;&nbsp;*(bool)Optional)*.<br>
+&nbsp;&nbsp;Select this checkbox of you want the Weather Alerts sensor added to Home Assistant.
+
+&nbsp;&nbsp;*Default value:*<br>
+&nbsp;&nbsp;False

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If the location is configured in Home Assistant, it will be selected as the defa
 
 During setup you will have the option of installing Individual sensors for each of the *Current Day* values plus the next seven days of Forecast. This will be setup by default, but you can opt not to install them by deselecting the checkbox. If you deselect, and later want the sensors installed, you will have to remove the Integration and then set it up again.
 
-You will also have the option of adding *Weather Alerts* for your location. It is de-selected by default, but if you mark the box, an additional sensor will be created for Weather Alerts, showing the number of Alerts in the State, and the details for these alerts in the attributes. If you want to add or remove this sensor, delete the Integrations and re-add it to the system.
+You will also have the option of adding *Weather Alerts* for your location. It is de-selected by default, but if you mark the box, an additional sensor will be created for Weather Alerts, showing the number of Alerts in the State, and the details for these alerts in the attributes. If you want to add or remove this sensor, delete the Integrations and re-add it to the system. For a very basic example of using the alerts in Lovelace, I modified some code from @eggman and you can find the [example here](https://github.com/briis/weatherbit/blob/master/weather_alert_markdown.yaml)
 
 The units used are defined by the Unit System set in the *General* section of the *Configuration* page. If you change the unit system here, you will have to restart Home Assistent for this Integration to reflect the changes.
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ If you activate the *Weather Alerts* that will add another 2 calls per hour with
 
 If you set Forecast Update Interval to every 60 min, and Current Data Update Interval to every 10 min, and activate the Weather Alerts, the calculation would look like the following:<br>
 
-* *Forecast* 1 * 60min * 24hrs = 24 calls per day
-* *Current Data* 1 * 10min * 24hrs = 144 calls per day
-* *Weather Alerts* 1 * 60min * 24hrs = 24 calls per day
+* *Forecast* 1 * 60/60min * 24hrs = 24 calls per day
+* *Current Data* 1 * 60/10min * 24hrs = 144 calls per day
+* *Weather Alerts* 1 * 60/60min * 24hrs = 24 calls per day
 * **Total**: 192 calls per day. So with this setup, you can have 2 locations in total configured.
 
 ### CONFIGURATION VARIABLES
@@ -105,7 +105,7 @@ If you set Forecast Update Interval to every 60 min, and Current Data Update Int
 &nbsp;&nbsp;*Default value:*<br>
 &nbsp;&nbsp;True
 
-**Activate Alertss**<br>
+**Activate Alerts**<br>
 &nbsp;&nbsp;*(bool)Optional)*.<br>
 &nbsp;&nbsp;Select this checkbox of you want the Weather Alerts sensor added to Home Assistant.
 

--- a/custom_components/weatherbit/__init__.py
+++ b/custom_components/weatherbit/__init__.py
@@ -128,7 +128,7 @@ async def _async_get_or_create_weatherbit_device_in_registry(
         identifiers={(DOMAIN, device_key)},
         manufacturer=DEFAULT_BRAND,
         name=entry.data[CONF_ID],
-        model="Current and Forecast Weather Data",
+        model="Weatherbit.io API",
     )
 
 

--- a/custom_components/weatherbit/__init__.py
+++ b/custom_components/weatherbit/__init__.py
@@ -70,6 +70,17 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         update_interval=fcst_scan_interval,
     )
 
+    if entry.data.get(CONF_ADD_ALERTS):
+        alert_coordinator = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_method=weatherbit.async_get_weather_alerts,
+            update_interval=fcst_scan_interval,
+        )
+    else:
+        alert_coordinator = None
+
     if entry.data.get(CONF_CUR_UPDATE_INTERVAL):
         current_scan_interval = timedelta(minutes=entry.data[CONF_CUR_UPDATE_INTERVAL])
     else:
@@ -85,10 +96,13 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     await fcst_coordinator.async_refresh()
     await cur_coordinator.async_refresh()
+    if entry.data.get(CONF_ADD_ALERTS):
+        await alert_coordinator..async_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {
         "fcst_coordinator": fcst_coordinator,
         "cur_coordinator": cur_coordinator,
+        "alert_coordinator": alert_coordinator,
         "weatherbit": weatherbit,
     }
 

--- a/custom_components/weatherbit/__init__.py
+++ b/custom_components/weatherbit/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     DOMAIN,
     CONF_CUR_UPDATE_INTERVAL,
     CONF_FCS_UPDATE_INTERVAL,
+    CONF_ADD_ALERTS,
     DEFAULT_BRAND,
     DEFAULT_SCAN_INTERVAL,
     WEATHERBIT_PLATFORMS,
@@ -97,7 +98,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     await fcst_coordinator.async_refresh()
     await cur_coordinator.async_refresh()
     if entry.data.get(CONF_ADD_ALERTS):
-        await alert_coordinator..async_refresh()
+        await alert_coordinator.async_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {
         "fcst_coordinator": fcst_coordinator,

--- a/custom_components/weatherbit/config_flow.py
+++ b/custom_components/weatherbit/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     DEFAULT_SCAN_INTERVAL,
     CONF_ADD_SENSORS,
+    CONF_ADD_ALERTS,
     CONF_CUR_UPDATE_INTERVAL,
     CONF_FCS_UPDATE_INTERVAL,
 )
@@ -53,6 +54,7 @@ class WeatherbitFlowHandler(ConfigFlow):
                         CONF_CUR_UPDATE_INTERVAL, default=DEFAULT_SCAN_INTERVAL
                     ): vol.All(vol.Coerce(int), vol.Range(min=4, max=60)),
                     vol.Optional(CONF_ADD_SENSORS, default=True): bool,
+                    vol.Optional(CONF_ADD_ALERTS, default=False): bool,
                 }
             ),
             errors=errors or {},
@@ -92,5 +94,6 @@ class WeatherbitFlowHandler(ConfigFlow):
                 CONF_FCS_UPDATE_INTERVAL: user_input.get(CONF_FCS_UPDATE_INTERVAL),
                 CONF_CUR_UPDATE_INTERVAL: user_input.get(CONF_CUR_UPDATE_INTERVAL),
                 CONF_ADD_SENSORS: user_input.get(CONF_ADD_SENSORS),
+                CONF_ADD_ALERTS: user_input.get(CONF_ADD_ALERTS),
             },
         )

--- a/custom_components/weatherbit/const.py
+++ b/custom_components/weatherbit/const.py
@@ -15,6 +15,7 @@ ATTR_WEATHERBIT_WEATHER_TEXT = "weather_text"
 ATTR_WEATHERBIT_WEATHER_ICON = "weather_icon"
 
 CONF_ADD_SENSORS = "add_sensors"
+CONF_ADD_ALERTS = "add_alerts"
 CONF_CUR_UPDATE_INTERVAL = "cur_update_interval"
 CONF_FCS_UPDATE_INTERVAL = "fcs_update_interval"
 

--- a/custom_components/weatherbit/const.py
+++ b/custom_components/weatherbit/const.py
@@ -4,13 +4,14 @@ import logging
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 
 ATTR_WEATHERBIT_AQI = "aqi"
+ATTR_WEATHERBIT_ALERTS = "alerts"
 ATTR_WEATHERBIT_CLOUDINESS = "cloudiness"
 ATTR_WEATHERBIT_IS_NIGHT = "is_night"
 ATTR_WEATHERBIT_WIND_GUST = "wind_gust"
 ATTR_WEATHERBIT_PRECIPITATION = "precipitation"
 ATTR_WEATHERBIT_UVI = "uv_index"
 ATTR_WEATHERBIT_UPDATED = "updated"
-ATTR_WEATHERBIT_FCST_POP = "precip_prop"
+ATTR_WEATHERBIT_FCST_POP = "precip_prob"
 ATTR_WEATHERBIT_WEATHER_TEXT = "weather_text"
 ATTR_WEATHERBIT_WEATHER_ICON = "weather_icon"
 
@@ -31,6 +32,7 @@ DEVICE_TYPE_DISTANCE = "distance"
 
 TYPE_SENSOR = "sensor"
 TYPE_FORECAST = "forecast"
+TYPE_ALERT = "alert"
 
 WEATHERBIT_PLATFORMS = [
     "weather",

--- a/custom_components/weatherbit/entity.py
+++ b/custom_components/weatherbit/entity.py
@@ -19,11 +19,14 @@ from .const import (
 class WeatherbitEntity(Entity):
     """Base class for Weatherbit Entities."""
 
-    def __init__(self, fcst_coordinator, cur_coordinator, entries, entity):
+    def __init__(
+        self, fcst_coordinator, cur_coordinator, alert_coordinator, entries, entity
+    ):
         """Initialize the Weatherbit Entity."""
         super().__init__()
         self.fcst_coordinator = fcst_coordinator
         self.cur_coordinator = cur_coordinator
+        self.alert_coordinator = alert_coordinator
         self.entries = entries
         self._entity = entity
         self._device_key = (
@@ -48,6 +51,12 @@ class WeatherbitEntity(Entity):
     def _current(self):
         """Return Current Data."""
         return self.cur_coordinator.data[0]
+
+    @property
+    def _alerts(self):
+        """Return Current Data."""
+        if self.alert_coordinator is not None:
+            return self.alert_coordinator.data[0]
 
     @property
     def _latitude(self):

--- a/custom_components/weatherbit/entity.py
+++ b/custom_components/weatherbit/entity.py
@@ -68,7 +68,7 @@ class WeatherbitEntity(Entity):
         return {
             "connections": {(dr.CONNECTION_NETWORK_MAC, self._device_key)},
             "manufacturer": DEFAULT_BRAND,
-            "model": "Current and Forecast Weather Data",
+            "model": "Weatherbit.io API",
             "via_device": (DOMAIN, self._device_key),
         }
 

--- a/custom_components/weatherbit/strings.json
+++ b/custom_components/weatherbit/strings.json
@@ -10,7 +10,8 @@
                     "longitude": "Longitude",
                     "fcs_update_interval": "Forecast Data Update Interval (Minutes)",
                     "cur_update_interval": "Current Data Update Interval (Minutes)",
-                    "add_sensors": "Install individual sensors"
+                    "add_sensors": "Install individual sensors",
+                    "add_alerts": "Activate Severe Weather Alerts"
                 }
             }
         },

--- a/custom_components/weatherbit/translations/da.json
+++ b/custom_components/weatherbit/translations/da.json
@@ -7,6 +7,7 @@
         "step": {
             "user": {
                 "data": {
+                    "add_alerts": "Aktivér Vejr Varsler",
                     "add_sensors": "Installer individuelle sensorer",
                     "cur_update_interval": "Aktuelle Data opdaterings interval (Minutter)",
                     "fcs_update_interval": "Forecast Data opdaterings interval (Minutter)",

--- a/custom_components/weatherbit/translations/en.json
+++ b/custom_components/weatherbit/translations/en.json
@@ -7,6 +7,7 @@
         "step": {
             "user": {
                 "data": {
+                    "add_alerts": "Activate Severe Weather Alerts",
                     "add_sensors": "Install individual sensors",
                     "cur_update_interval": "Current Data Update Interval (Minutes)",
                     "fcs_update_interval": "Forecast Data Update Interval (Minutes)",

--- a/custom_components/weatherbit/weather.py
+++ b/custom_components/weatherbit/weather.py
@@ -74,7 +74,7 @@ class WeatherbitWeather(WeatherbitEntity, WeatherEntity):
     def __init__(self, fcst_coordinator, cur_coordinator, entries, is_metric) -> None:
         """Initialize the Weatherbit weather entity."""
         super().__init__(
-            fcst_coordinator, cur_coordinator, entries, DEVICE_TYPE_WEATHER
+            fcst_coordinator, cur_coordinator, None, entries, DEVICE_TYPE_WEATHER
         )
         self._name = f"{DOMAIN.capitalize()} {entries[CONF_ID].capitalize()}"
         self._is_metric = is_metric

--- a/weather_alert_markdown.yaml
+++ b/weather_alert_markdown.yaml
@@ -1,0 +1,29 @@
+
+- type: markdown
+  style: 'ha-card { --iron-icon-width: 50px; --iron-icon-height: 50px; }'
+  content: >-
+    {% if states.sensor.weatherbit_weather_alerts.state | int > 0 %}
+      {% for item in state_attr('sensor.weatherbit_weather_alerts','alerts') %}
+        {% for type, icon in [('Advisory', 'shield-alert'), ('Watch', 'alert-circle'),
+                              ('Warning', 'alert')] if type == item['severity']|trim("[]'") %}
+    ---
+
+    | | | |
+
+    | --- | --- | --- |
+
+    | <font color = {%- if 'Advisory' in item.severity|trim("'[]'")
+    %}'gold'
+                {%- elif 'Watch' in item.severity|trim("'[]'") %}'darkorange'
+                {%- else %}'firebrick'
+                {%- endif %}><ha-icon icon={{ "'mdi:" + icon + "'" }}></ha-icon></font> | |
+                From: {{ item.effective_local }} |
+                To: {{ item.expires_local }} |
+                More info: {{ item.uri }} |
+
+    {{ item.description|trim("'[]'") }}  |
+    {% endfor %}
+
+      {% endfor %}
+    {% endif %}
+  title: Weather Alerts


### PR DESCRIPTION
* Added **Weather Alerts**. If selected during config, there will now be a new sensor added, called `weather_alerts`. The state of the sensor shows the number of alerts for the selected location, and the Attributes hold the details for the alert. See the README.md file for an example on how to use this.<br>
Update frequency for the Weather Alerts follows what you set for the Forecast - Default 30 min.<br>
**NOTE**: You must remove the Integration and Re-Add it before given the option of adding the Weather Alerts sensor.
* Other minor cosmetic changes