### PR TITLE
V0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ icons/logo@2x.png
 custom_components/weatherbit/config_flow_org.py
 custom_components/weatherbit/config_flow_new.py
 accuforecast.json
+custom_components/weatherbit/config_flow_old.py

--- a/custom_components/weatherbit/__init__.py
+++ b/custom_components/weatherbit/__init__.py
@@ -52,8 +52,6 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
             options={
                 "fcs_update_interval": entry.data[CONF_FCS_UPDATE_INTERVAL],
                 "cur_update_interval": entry.data[CONF_CUR_UPDATE_INTERVAL],
-                "add_sensors": entry.data[CONF_ADD_SENSORS],
-                "add_alerts": entry.data[CONF_ADD_ALERTS],
             },
         )
 
@@ -83,7 +81,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         update_interval=fcst_scan_interval,
     )
 
-    if entry.options.get(CONF_ADD_ALERTS):
+    if entry.data.get(CONF_ADD_ALERTS):
         alert_coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,
@@ -111,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
 
     await fcst_coordinator.async_refresh()
     await cur_coordinator.async_refresh()
-    if entry.options.get(CONF_ADD_ALERTS):
+    if entry.data.get(CONF_ADD_ALERTS):
         await alert_coordinator.async_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {

--- a/custom_components/weatherbit/__init__.py
+++ b/custom_components/weatherbit/__init__.py
@@ -149,13 +149,13 @@ async def _async_get_or_create_weatherbit_device_in_registry(
     )
 
 
-async def async_update_options(hass, config_entry):
+async def async_update_options(hass: HomeAssistantType, entry: ConfigEntry):
     """Update options."""
-    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
-    """Unload Unifi Protect config entry."""
+    """Unload Weatherbit config entry."""
     unload_ok = all(
         await asyncio.gather(
             *[

--- a/custom_components/weatherbit/config_flow.py
+++ b/custom_components/weatherbit/config_flow.py
@@ -12,8 +12,9 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
 )
-from homeassistant.config_entries import ConfigFlow
+from homeassistant import config_entries, core
 import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
 
 from .const import (
     DOMAIN,
@@ -27,15 +28,64 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class WeatherbitFlowHandler(ConfigFlow):
-    """Config flow for Weatherbit component."""
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect.
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    wbit_client = Weatherbit(
+        data[CONF_API_KEY], data[CONF_LATITUDE], data[CONF_LONGITUDE],
+    )
+
+    unique_id = await wbit_client.async_get_city_name()
+
+    return unique_id
+
+
+class WeatherbitConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Weatherbit configuration flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def _show_setup_form(self, errors=None):
-        """Show the setup form to the user."""
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+            await self.async_set_unique_id(
+                f"{user_input[CONF_LATITUDE]}_{user_input[CONF_LONGITUDE]}"
+            )
+            self._abort_if_unique_id_configured()
+            try:
+                info = await validate_input(self.hass, user_input)
+            except WeatherbitError:
+                errors = {"base": "connection_error"}
+
+            if "base" not in errors:
+                return self.async_create_entry(
+                    title=info,
+                    data={
+                        CONF_ID: info,
+                        CONF_API_KEY: user_input[CONF_API_KEY],
+                        CONF_LATITUDE: user_input[CONF_LATITUDE],
+                        CONF_LONGITUDE: user_input.get(CONF_LONGITUDE),
+                        CONF_FCS_UPDATE_INTERVAL: user_input.get(
+                            CONF_FCS_UPDATE_INTERVAL
+                        ),
+                        CONF_CUR_UPDATE_INTERVAL: user_input.get(
+                            CONF_CUR_UPDATE_INTERVAL
+                        ),
+                        CONF_ADD_SENSORS: user_input.get(CONF_ADD_SENSORS),
+                        CONF_ADD_ALERTS: user_input.get(CONF_ADD_ALERTS),
+                    },
+                )
+
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
@@ -57,43 +107,46 @@ class WeatherbitFlowHandler(ConfigFlow):
                     vol.Optional(CONF_ADD_ALERTS, default=False): bool,
                 }
             ),
-            errors=errors or {},
+            errors=errors,
         )
 
-    async def async_step_user(self, user_input=None):
-        """Handle a flow initiated by the user."""
-        if user_input is None:
-            return await self._show_setup_form(user_input)
 
-        errors = {}
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
 
-        wbit_client = Weatherbit(
-            user_input[CONF_API_KEY],
-            user_input[CONF_LATITUDE],
-            user_input[CONF_LONGITUDE],
-        )
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
 
-        try:
-            unique_id = await wbit_client.async_get_city_name()
-        except WeatherbitError:
-            errors["base"] = "connection_error"
-            return await self._show_setup_form(errors)
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
 
-        entries = self._async_current_entries()
-        for entry in entries:
-            if entry.data[CONF_ID] == unique_id:
-                return self.async_abort(reason="name_exists")
-
-        return self.async_create_entry(
-            title=unique_id,
-            data={
-                CONF_ID: unique_id,
-                CONF_API_KEY: user_input[CONF_API_KEY],
-                CONF_LATITUDE: user_input[CONF_LATITUDE],
-                CONF_LONGITUDE: user_input.get(CONF_LONGITUDE),
-                CONF_FCS_UPDATE_INTERVAL: user_input.get(CONF_FCS_UPDATE_INTERVAL),
-                CONF_CUR_UPDATE_INTERVAL: user_input.get(CONF_CUR_UPDATE_INTERVAL),
-                CONF_ADD_SENSORS: user_input.get(CONF_ADD_SENSORS),
-                CONF_ADD_ALERTS: user_input.get(CONF_ADD_ALERTS),
-            },
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_FCS_UPDATE_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_FCS_UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=30, max=120)),
+                    vol.Optional(
+                        CONF_CUR_UPDATE_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_CUR_UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=4, max=60)),
+                    vol.Optional(
+                        CONF_ADD_SENSORS,
+                        default=self.config_entry.options.get(CONF_ADD_SENSORS, True),
+                    ): bool,
+                    vol.Optional(
+                        CONF_ADD_ALERTS,
+                        default=self.config_entry.options.get(CONF_ADD_ALERTS, False),
+                    ): bool,
+                }
+            ),
         )

--- a/custom_components/weatherbit/config_flow.py
+++ b/custom_components/weatherbit/config_flow.py
@@ -139,14 +139,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_CUR_UPDATE_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=4, max=60)),
-                    vol.Optional(
-                        CONF_ADD_SENSORS,
-                        default=self.config_entry.options.get(CONF_ADD_SENSORS, True),
-                    ): bool,
-                    vol.Optional(
-                        CONF_ADD_ALERTS,
-                        default=self.config_entry.options.get(CONF_ADD_ALERTS, False),
-                    ): bool,
+                    # vol.Optional(
+                    #     CONF_ADD_SENSORS,
+                    #     default=self.config_entry.options.get(CONF_ADD_SENSORS, True),
+                    # ): bool,
+                    # vol.Optional(
+                    #     CONF_ADD_ALERTS,
+                    #     default=self.config_entry.options.get(CONF_ADD_ALERTS, False),
+                    # ): bool,
                 }
             ),
         )

--- a/custom_components/weatherbit/sensor.py
+++ b/custom_components/weatherbit/sensor.py
@@ -81,7 +81,7 @@ async def async_setup_entry(
 
     # Exit if user did deselect sensors and alerts on config
     if (
-        not entry.data[CONF_ADD_SENSORS]
+        not entry.options[CONF_ADD_SENSORS]
         and hass.data[DOMAIN][entry.entry_id]["alert_coordinator"] is None
     ):
         return
@@ -100,7 +100,7 @@ async def async_setup_entry(
     sensors = []
 
     # Add Sensors if selected in Config
-    if entry.data[CONF_ADD_SENSORS]:
+    if entry.options[CONF_ADD_SENSORS]:
         for sensor in SENSORS:
             sensors.append(
                 WeatherbitSensor(

--- a/custom_components/weatherbit/sensor.py
+++ b/custom_components/weatherbit/sensor.py
@@ -81,7 +81,7 @@ async def async_setup_entry(
 
     # Exit if user did deselect sensors and alerts on config
     if (
-        not entry.options[CONF_ADD_SENSORS]
+        not entry.data[CONF_ADD_SENSORS]
         and hass.data[DOMAIN][entry.entry_id]["alert_coordinator"] is None
     ):
         return
@@ -100,7 +100,7 @@ async def async_setup_entry(
     sensors = []
 
     # Add Sensors if selected in Config
-    if entry.options[CONF_ADD_SENSORS]:
+    if entry.data[CONF_ADD_SENSORS]:
         for sensor in SENSORS:
             sensors.append(
                 WeatherbitSensor(

--- a/custom_components/weatherbit/strings.json
+++ b/custom_components/weatherbit/strings.json
@@ -19,5 +19,17 @@
             "name_exists": "Location already setup. Choose other coordinates.",
             "connection_error": "Could not connect to Weatherbit. Check API Key."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "add_alerts": "Activate Severe Weather Alerts",
+                    "add_sensors": "Install individual sensors",
+                    "cur_update_interval": "Current Data Update Interval (Minutes)",
+                    "fcs_update_interval": "Forecast Data Update Interval (Minutes)"
+                }
+            }
+        }
     }
 }

--- a/custom_components/weatherbit/translations/da.json
+++ b/custom_components/weatherbit/translations/da.json
@@ -19,5 +19,17 @@
                 "title": "Placering for Weatherbit Data"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "add_alerts": "Aktivér Vejr Varsler",
+                    "add_sensors": "Installer individuelle sensorer",
+                    "cur_update_interval": "Aktuelle Data opdaterings interval (Minutter)",
+                    "fcs_update_interval": "Forecast Data opdaterings interval (Minutter)"
+                }
+            }
+        }
     }
 }

--- a/custom_components/weatherbit/translations/en.json
+++ b/custom_components/weatherbit/translations/en.json
@@ -19,5 +19,17 @@
                 "title": "Location for Weatherbit Data"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "add_alerts": "Activate Severe Weather Alerts",
+                    "add_sensors": "Install individual sensors",
+                    "cur_update_interval": "Current Data Update Interval (Minutes)",
+                    "fcs_update_interval": "Forecast Data Update Interval (Minutes)"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
* Added Option to change Configuration Settings from the Integrations Menu without deleting and re-adding the Integration. 
Currently you can only change the Forecast and Current Data update Intervals. I have managed to also handle adding sensors that were not added on load, but I have not figured out how to remove them again, if the sensor or Weather Alert is de-selected. So therefore I left this out for now.